### PR TITLE
chore: add a field acting as a comment indicating the source URL for tsErrorMessages.json

### DIFF
--- a/packages/engine/src/tsErrorMessages.json
+++ b/packages/engine/src/tsErrorMessages.json
@@ -1,4 +1,6 @@
 {
+  "__Source__": "https://github.com/microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json",
+  
   "Unterminated string literal.": {
     "category": "Error",
     "code": 1002


### PR DESCRIPTION
I was curious where did you get this data from and I think most contributors would also do, so I included the URL for the file source.

Note: JSON doesn't support comments, so `__comment__` as a field is a common convention when writing comments in JSON these days.