### PR TITLE
fix(scripts): exiting the process with error code in the proper places

### DIFF
--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -6,23 +6,24 @@ const errorCode = process.argv[2]
 
 if (!errorCode) {
   logger.error(`\nYou've to provide an error code for your translation!`)
-  process.exit(1);
   logger.info(`Example:`)
   logger.info(`  yarn translate 1006`)
-} else {
-  const template = fs.readFileSync(
-    path.join(__dirname, './templates/error.md'),
-    'utf-8'
-  )
-
-  const errorPath = `packages/engine/errors/${errorCode}.md`
-
-  if (fs.existsSync(errorPath)) {
-    logger.error(`\nTranslation for error code ${errorCode} already exists!`)
-  } else {
-    fs.writeFileSync(errorPath, template)
-
-    logger.success('\nTemplate has been written Successfuly!')
-    logger.info(`Check: ${errorPath}`)
-  }
+  process.exit(1)
 }
+
+const template = fs.readFileSync(
+  path.join(__dirname, './templates/error.md'),
+  'utf-8'
+)
+
+const errorPath = `packages/engine/errors/${errorCode}.md`
+
+if (fs.existsSync(errorPath)) {
+  logger.error(`\nTranslation for error code ${errorCode} already exists!`)
+  process.exit(1)
+}
+
+fs.writeFileSync(errorPath, template)
+
+logger.success('\nTemplate has been written Successfuly!')
+logger.info(`Check: ${errorPath}`)


### PR DESCRIPTION
In this merged PR #7.

You've modified it to exit the process before printing out the example on how the script should be run:

```js
if (!errorCode) {
  logger.error(`\nYou've to provide an error code for your translation!`)
  process.exit(1) // <---- Here
  logger.info(`Example:`)
  logger.info(`  yarn translate 1006`)
}
```

so I exited after letting the user know what went wrong and substituted else statements with `process.exit(1)` in the if blocks for clarity.