### PR TITLE
fix(error 1009): speak like if I was the typescript compiler but more friendly

### DIFF
--- a/packages/engine/errors/1009.md
+++ b/packages/engine/errors/1009.md
@@ -3,4 +3,4 @@ original: "Trailing comma not allowed."
 excerpt: "You've added a trailing comma when you're not supposed to add it"
 ---
 
-You should remove the trailing comma where I'm pointing to make me happy :)
+You should remove the trailing comma where I'm pointing - otherwise, I won't be able to understand your code.

--- a/packages/engine/errors/1009.md
+++ b/packages/engine/errors/1009.md
@@ -3,4 +3,4 @@ original: "Trailing comma not allowed."
 excerpt: "You've added a trailing comma when you're not supposed to add it"
 ---
 
-You should remove the trailing comma where the typescript compiler is pointing to make Typescript happy :)
+You should remove the trailing comma where I'm pointing to make me happy :)

--- a/scripts/templates/error.md
+++ b/scripts/templates/error.md
@@ -1,6 +1,6 @@
 ---
 original: "Original error message"
-excerpt: "Simplified version of the error message (Use "you" as the pronoun because it feels friendly and talk as if you were the compiler)"
+excerpt: "Simplified version of the error message"
 ---
 
 More details, reproducible examples for the error and How the error should be fixed.

--- a/scripts/templates/error.md
+++ b/scripts/templates/error.md
@@ -1,6 +1,6 @@
 ---
 original: "Original error message"
-excerpt: "Simplified version of the error message (Use "you" as the pronoun because it feels friendly)"
+excerpt: "Simplified version of the error message (Use "you" as the pronoun because it feels friendly and talk as if you were the compiler)"
 ---
 
 More details, reproducible examples for the error and How the error should be fixed.

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -6,23 +6,24 @@ const errorCode = process.argv[2]
 
 if (!errorCode) {
   logger.error(`\nYou've to provide an error code for your translation!`)
-  process.exit(1);
   logger.info(`Example:`)
   logger.info(`  yarn translate 1006`)
-} else {
-  const template = fs.readFileSync(
-    path.join(__dirname, './templates/error.md'),
-    'utf-8'
-  )
-
-  const errorPath = `packages/engine/errors/${errorCode}.md`
-
-  if (fs.existsSync(errorPath)) {
-    logger.error(`\nTranslation for error code ${errorCode} already exists!`)
-  } else {
-    fs.writeFileSync(errorPath, template)
-
-    logger.success('\nTemplate has been written Successfuly!')
-    logger.info(`Check: ${errorPath}`)
-  }
+  process.exit(1)
 }
+
+const template = fs.readFileSync(
+  path.join(__dirname, './templates/error.md'),
+  'utf-8'
+)
+
+const errorPath = `packages/engine/errors/${errorCode}.md`
+
+if (fs.existsSync(errorPath)) {
+  logger.error(`\nTranslation for error code ${errorCode} already exists!`)
+  process.exit(1)
+}
+
+fs.writeFileSync(errorPath, template)
+
+logger.success('\nTemplate has been written Successfuly!')
+logger.info(`Check: ${errorPath}`)

--- a/scripts/translate.ts
+++ b/scripts/translate.ts
@@ -6,24 +6,23 @@ const errorCode = process.argv[2]
 
 if (!errorCode) {
   logger.error(`\nYou've to provide an error code for your translation!`)
+  process.exit(1);
   logger.info(`Example:`)
   logger.info(`  yarn translate 1006`)
-  process.exit(1)
+} else {
+  const template = fs.readFileSync(
+    path.join(__dirname, './templates/error.md'),
+    'utf-8'
+  )
+
+  const errorPath = `packages/engine/errors/${errorCode}.md`
+
+  if (fs.existsSync(errorPath)) {
+    logger.error(`\nTranslation for error code ${errorCode} already exists!`)
+  } else {
+    fs.writeFileSync(errorPath, template)
+
+    logger.success('\nTemplate has been written Successfuly!')
+    logger.info(`Check: ${errorPath}`)
+  }
 }
-
-const template = fs.readFileSync(
-  path.join(__dirname, './templates/error.md'),
-  'utf-8'
-)
-
-const errorPath = `packages/engine/errors/${errorCode}.md`
-
-if (fs.existsSync(errorPath)) {
-  logger.error(`\nTranslation for error code ${errorCode} already exists!`)
-  process.exit(1)
-}
-
-fs.writeFileSync(errorPath, template)
-
-logger.success('\nTemplate has been written Successfuly!')
-logger.info(`Check: ${errorPath}`)


### PR DESCRIPTION
As said [here](https://github.com/mattpocock/ts-error-translator/pull/5#discussion_r860551295), It feels nicer to talk as the typescript compiler in a friendly way.