### PR TITLE
chore(error template): add a note to check the translation guide first

### DIFF
--- a/scripts/templates/error.md
+++ b/scripts/templates/error.md
@@ -1,3 +1,5 @@
+<!-- Please check our translation style guide: https://bit.ly/3kiwzcd -->
+
 ---
 original: "Original error message"
 excerpt: "Simplified version of the error message (Use "you" as the pronoun because it feels friendly and talk as if you were the compiler)"


### PR DESCRIPTION
As discussed [here](https://github.com/mattpocock/ts-error-translator/pull/12#discussion_r861101182), the translation style guide is in `contributing.md`.

So adding a note for contributors to check it first would be helpful for getting quality translations from them.

Note: the link is a shortened using [Bitly](https://bitly.com/) cause It's ugly to include the full URL as a note (Ex: https://github.com/mattpocock/ts-error-translator/blob/main/CONTRIBUTING.md?utm_source=github#translation-style-guide)