### PR TITLE
fix(engine): match non-quoted args in diagnostic messages

### DIFF
--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -137,4 +137,58 @@ describe("parseErrors", () => {
 
     expect(errors).toHaveLength(2);
   });
+
+  it("should match diagnostic variadic arguments for quoted types and arbitrary (non-quoted) values", () => {
+    const input = `
+      Generic type 'T' requires between 5 and 10 type arguments.
+      Type 'B' is missing the following properties from type 'A': two, three
+      'T' refers to a value, but is being used as a type here. Did you mean 'typeof T'?
+    `;
+    const errors = parseErrors(input);
+
+    expect(errors).toMatchInlineSnapshot(`
+      [
+        {
+          "code": 2707,
+          "error": "Generic type '{0}' requires between {1} and {2} type arguments.",
+          "parseInfo": {
+            "endIndex": 7,
+            "items": [
+              "T",
+              "5",
+              "10",
+            ],
+            "rawError": "Generic type 'T' requires between 5 and 10 type arguments.",
+            "startIndex": 7,
+          },
+        },
+        {
+          "code": 2739,
+          "error": "Type '{0}' is missing the following properties from type '{1}': {2}",
+          "parseInfo": {
+            "endIndex": 72,
+            "items": [
+              "B",
+              "A",
+              "two, three",
+            ],
+            "rawError": "Type 'B' is missing the following properties from type 'A': two, three",
+            "startIndex": 72,
+          },
+        },
+        {
+          "code": 2749,
+          "error": "'{0}' refers to a value, but is being used as a type here. Did you mean 'typeof {0}'?",
+          "parseInfo": {
+            "endIndex": 149,
+            "items": [
+              "T",
+            ],
+            "rawError": "'T' refers to a value, but is being used as a type here. Did you mean 'typeof T'?",
+            "startIndex": 149,
+          },
+        },
+      ]
+    `);
+  });
 });

--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -146,6 +146,7 @@ describe("parseErrors", () => {
     `;
     const errors = parseErrors(input);
 
+    // TODO - assert based on the items, not on the snapshot
     expect(errors).toMatchInlineSnapshot(`
       [
         {

--- a/packages/engine/src/parseErrors.ts
+++ b/packages/engine/src/parseErrors.ts
@@ -10,7 +10,7 @@ const toRegex = (key: string): RegExp => {
   if (regexCache[key]) {
     return regexCache[key];
   }
-  const regex = escapeRegExp(key).replace(/'\\\{(\d)\\\}'/g, "'(.{1,})'");
+  const regex = escapeRegExp(key).replace(/\\\{(\d)\\\}/g, "(.{1,})");
 
   regexCache[key] = new RegExp(regex, "g");
 
@@ -22,7 +22,7 @@ const toNonGlobalRegex = (key: string): RegExp => {
   if (regexCache[adjustedKey]) {
     return regexCache[adjustedKey];
   }
-  const regex = escapeRegExp(key).replace(/'\\\{(\d)\\\}'/g, "'(.{1,})'");
+  const regex = escapeRegExp(key).replace(/\\\{(\d)\\\}/g, "(.{1,})");
 
   regexCache[adjustedKey] = new RegExp(regex);
 


### PR DESCRIPTION
Hey 👋 

So, there are a couple of cases where the current regular expression never matches.
These are the diagnostic key/messages:
```
Generic type '{0}' requires between {1} and {2} type arguments.
Type '{0}' is missing the following properties from type '{1}': {2}
'{0}' refers to a value, but is being used as a type here. Did you mean 'typeof {0}'?
```
In the first case, `{1}` and `{2}` are numeric values but regex only builds to include if its within single quotes (only matches types).
In the second case is trickier because `{2}` is kind of an arbitrary string value.
In the last case, `'typeof {0}'` does not match number within `'{\d}'` so the regex will not match

Examples:
```
Generic type 'T' requires between 5 and 10 type arguments.
Type 'B' is missing the following properties from type 'A': two, three
'T' refers to a value, but is being used as a type here. Did you mean 'typeof T'?
```

I think the easiest solution is to do:
```diff
- const regex = escapeRegExp(key).replace(/'\\\{(\d)\\\}'/g, "'(.{1,})'");
+ const regex = escapeRegExp(key).replace(/\\\{(\d)\\\}/g, "(.{1,})");
```

Then you see all 3 errors which previously didn't show up:
<img width="675" alt="Screen Shot 2022-04-30 at 00 58 02" src="https://user-images.githubusercontent.com/1407526/165989729-d17828c7-3468-4735-911a-f076441084d8.png">