### PR TITLE
fix(2552): remove error code from the original error message

### DIFF
--- a/packages/engine/errors/2552.md
+++ b/packages/engine/errors/2552.md
@@ -1,5 +1,5 @@
 ---
-original: "TS2552: Cannot find name '{0}'. Did you mean '{1}'?"
+original: "Cannot find name '{0}'. Did you mean '{1}'?"
 excerpt: 'You are trying to reference a function or variable which Typescript cannot find within the scope.'
 ---
 


### PR DESCRIPTION
As discussed here #19 in my [comment](https://github.com/mattpocock/ts-error-translator/pull/19#commitcomment-72568170)