### PR TITLE
feat(engine): refactor cache and dedupe correctly number of similar arguments

### DIFF
--- a/.changeset/honest-singers-fail.md
+++ b/.changeset/honest-singers-fail.md
@@ -1,0 +1,5 @@
+---
+'@ts-error-messages/engine': minor
+---
+
+Correctly match duplicated matched parameters

--- a/packages/engine/src/getImprovedMessage.ts
+++ b/packages/engine/src/getImprovedMessage.ts
@@ -5,7 +5,7 @@ import fm from 'front-matter';
 export const getImprovedMessageFromMarkdown = (
   dir: string,
   code: number,
-  items: string[],
+  items: (string | number)[],
 ) => {
   const file = path.join(dir, `${code}.md`);
 
@@ -27,11 +27,11 @@ export const getImprovedMessageFromMarkdown = (
 export const fillBodyAndExcerptWithItems = (
   body: string,
   excerpt: string,
-  items: string[],
+  items: (string | number)[],
 ) => {
   items.forEach((item, index) => {
     const bodyRegex = new RegExp(`\\\{${index}\\\}`, 'g');
-    body = body.replace(bodyRegex, item);
+    body = body.replace(bodyRegex, item.toString());
     const excerptRegex = new RegExp(`'\\\{${index}\\\}'`, 'g');
     excerpt = excerpt.replace(excerptRegex, '`' + item + '`');
   });


### PR DESCRIPTION
# Description

Resolves #31 

The following lines were previously used to deduplicate parameters:
```ts
let [, ...items] = matchElem.match(nonGlobalRegex)!;
items = Array.from(new Set(items));
```
However, there are valid cases were, for example, `{0}` and `{1}` (...`{N}`) can be all of the same value. For instance:
```
Parameter 'any' implicitly has an 'any' type.
Property 'User' is missing in type 'User'.
```
Because of `Set` deduplicating values, it returns less arguments than expected. For example:
<img width="656" alt="Screen Shot 2022-05-03 at 01 08 43" src="https://user-images.githubusercontent.com/1407526/166292747-f6f4a5d1-925a-4929-9e91-a81f10ef38c0.png">

**What this PR does it is**

It creates an array of type - for instance - `["{0}", "{1}", "{0}"]` from the original diagnostic message. This is later used to map the matched arguments to a record object like this:
```ts
Params = ["{0}", "{1}", "{0}"]
Matches = ["A", "A", "A"] // To
Record = { "{0}": "A", "{1}": "A" }
```
Because in Javascript non-numeric (string) properties are kept in order of insertion, then we can safely get `Object.values(Record)` of ordered unique values:
```
"A", "A" -> {0}, {1}
```
which is what's expected.

<img width="576" alt="Screen Shot 2022-05-03 at 01 22 26" src="https://user-images.githubusercontent.com/1407526/166294553-2c83007e-58c2-4642-8dc8-45cc0743397b.png">

## Additional changes

I refactored the cache thing. It's still dynamic as it was before but now it can include additional properties such as `parameters` array. Idk, this made sense to do rather than create yet one more cache thing to store other props. Also, I used a `Map` instead of an object because +1000 keys already makes the object fall from "fast properties" to "dictionary mode" (in V8 at least) so `Map`s are better suited to store dictionary-like objects which contains more than 32 properties.

While getting keys from an object is fairly fast in V8, it doesn't need to happen for every function invocation, so I just moved it out of the function since the json file will never change during runtime, so keys are the same.

## Testing

How would you prefer to test this? 😅 I mean, if these changes are ok/accepted 😄 
imho, it should be a unit test, but exporting the internal methods will expose them in the `index.ts`, not sure if that's expected, or just pick what's exported in `index.ts` 🙈 