### PR TITLE
RFC: hashing diagnostic messages

### DIFF
--- a/packages/engine/src/parseErrors.ts
+++ b/packages/engine/src/parseErrors.ts
@@ -1,4 +1,5 @@
 import tsErrorMessages from './tsErrorMessages.json';
+import * as Diagnostic from './rfc/Diagnostic';
 
 function escapeRegExp(str: string) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
@@ -54,6 +55,23 @@ export interface ParseErrorsOpts {}
 export const parseErrors = (
   message: string,
 ): ErrorInfoWithoutImprovedError[] => {
+  /**
+   * Just a facade to that's compatible with the existing implementation to demonstrate how it works
+   * without breaking current app.
+   */
+  return Diagnostic.ParseMessage(message).map<ErrorInfoWithoutImprovedError>(
+    (diagnostic) => ({
+      code: diagnostic.code,
+      error: diagnostic.message,
+      parseInfo: {
+        startIndex: 0,
+        endIndex: 0,
+        rawError: diagnostic.matched,
+        items: diagnostic.parameters,
+      },
+    }),
+  );
+
   const errorMessageByKey: Record<string, ErrorInfoWithoutImprovedError> = {};
 
   (Object.keys(tsErrorMessages) as (keyof typeof tsErrorMessages)[]).forEach(

--- a/packages/engine/src/rfc/Diagnostic.ts
+++ b/packages/engine/src/rfc/Diagnostic.ts
@@ -1,0 +1,31 @@
+import * as DiagnosticMatcher from "./DiagnosticMatcher";
+import type {Diagnostic} from "./types";
+
+export function CreateMessageChain(messageChain: string): string[] {
+	const diagnosticMessageChain: string[] = messageChain
+		.split("\n")
+		.map((message) => message.trim())
+		.filter((messageChainItem) => messageChainItem.length > 5);
+	return Array.from(new Set(diagnosticMessageChain));
+}
+export function Create(message: string): Diagnostic | null {
+	const diagnosticMatcher = DiagnosticMatcher.Find(message);
+
+	if (!diagnosticMatcher) return null;
+
+	const parameters = message.match(diagnosticMatcher.matcher) ?? [];
+
+	return {
+		code: diagnosticMatcher.code,
+		category: diagnosticMatcher.category,
+		hashKey: diagnosticMatcher.hashKey,
+		message: diagnosticMatcher.message,
+		matched: message,
+		parameters: DiagnosticMatcher.AssociateParameters(diagnosticMatcher.parameters, parameters.slice(1)),
+	};
+}
+export function ParseMessage(text: string): Diagnostic[] {
+	const messageChain = CreateMessageChain(text);
+	const diagnostics = messageChain.map(Create).filter((d): d is Diagnostic => d !== null);
+	return diagnostics;
+}

--- a/packages/engine/src/rfc/DiagnosticMatcher.ts
+++ b/packages/engine/src/rfc/DiagnosticMatcher.ts
@@ -1,0 +1,102 @@
+import * as crypto from "node:crypto";
+import DiagnosticJsonMessages from "../tsErrorMessages.json";
+import type {HashKey} from "./types";
+import type {DiagnosticMatcher} from "./types";
+import type {DiagnosticJsonMessage} from "./types";
+
+const MatchRegExpEscape = /[.*+?^${}()|[\]\\]/g;
+const MatchDoubleQuoted = /"([^"]*)"/g;
+const MatchSingleQuoted = /'([^']*)'/g;
+const MatchEscapedQuote = /\\"/g;
+const MatchAnyParameter = /({.+})/g;
+const MatchIntParameter = /({\d})/g;
+const MatchEscapedParam = /\\\{(\d)\\\}/g;
+const DiagnosticHashMap = new Map<string, DiagnosticMatcher[]>();
+
+function ConvertToRegExpSource(text: string): string {
+	return text.replace(MatchRegExpEscape, "\\$&");
+}
+function ConvertDiagnosticMessageToHashKey(message: string): HashKey {
+	const noTypeArgumentsMessage = message
+		.replace(MatchEscapedQuote, "EQ") //  '\\" | "A"'  -> 'EQ | "A"'
+		.replace(MatchDoubleQuoted, "DQ") //  'EQ | "A"'   -> 'EQ | DQ'
+		.replace(MatchSingleQuoted, "'T'") // 'EQ | DQ'    -> 'T'
+		.replace(MatchAnyParameter, "{?}"); // '{0}' is {2} -> '{?}' is {?}
+
+	return crypto.createHash("sha256").update(noTypeArgumentsMessage).digest("hex");
+}
+function CreateDiagnosticMatcher(message: string, {code, category}: DiagnosticJsonMessage): DiagnosticMatcher {
+	const hashKey = ConvertDiagnosticMessageToHashKey(message);
+	const matchSource = ConvertToRegExpSource(message).replace(MatchEscapedParam, "(.+)"); // \{0\} -> (.+)
+
+	const matcher = new RegExp(`^${matchSource}$`);
+	const parameters = message.match(MatchIntParameter) ?? [];
+
+	return {
+		code,
+		category,
+		hashKey,
+		message,
+		matcher,
+		parameters,
+	};
+}
+function EnsureHashMapBuilt() {
+	if (DiagnosticHashMap.size === 0) {
+		const messages: Record<string, DiagnosticJsonMessage> = DiagnosticJsonMessages;
+
+		for (const message in messages) {
+			const diagnosticMatcher = CreateDiagnosticMatcher(message, messages[message]);
+			const groupedByHashKey = DiagnosticHashMap.get(diagnosticMatcher.hashKey) ?? [];
+
+			groupedByHashKey.push(diagnosticMatcher);
+
+			DiagnosticHashMap.set(diagnosticMatcher.hashKey, groupedByHashKey);
+		}
+	}
+}
+export function Find(message: string): DiagnosticMatcher | null {
+	EnsureHashMapBuilt();
+
+	const messageHashKey = ConvertDiagnosticMessageToHashKey(message);
+	const diagnosticMatcherGroup = DiagnosticHashMap.get(messageHashKey);
+
+	/**
+	 * In the best case (most cases), there'll be a single element in the group.
+	 * However, hash collisions are possible for diagnostics that look-alike
+	 * after cleaning up their arguments (e.g: quoted values).
+	 * In few worst cases, a group contains multiple diagnostics (~2-3) with same hash,
+	 * this is still faster that iterating over all +1000 diagnostics vs ~3 diagnostics.
+	 */
+	if (diagnosticMatcherGroup) {
+		for (const diagnosticMatcher of diagnosticMatcherGroup) {
+			if (message.match(diagnosticMatcher.matcher)) {
+				return diagnosticMatcher;
+			}
+		}
+	}
+
+	return null;
+}
+/**
+ * Associate a diagnostic message parameters with a matched message parameters,
+ * returning an array of unique parameter associations.
+ * @example
+ * ```ts
+ * AssociateParameters(["{0}", "{1}", "{0}", "{2}"], ["T", "U", "T", "T"]); // ["T", "U", "T"]
+ * ```
+ */
+export function AssociateParameters(parameters: string[], matchedParameters: string[]): string[] {
+	const params: Record<string, string> = Object.create(null);
+
+	for (let i = 0; i < matchedParameters.length; i++) {
+		const parameter = parameters[i];
+		/**
+		 * If a user provides a made-up diagnostic message (that matches), parameters may not be associable,
+		 * so we'll just ignore them by defaulting to displaying "unknown".
+		 */
+		params[parameter] ??= String(matchedParameters[i] ?? "unknown");
+	}
+
+	return Object.values(params);
+}

--- a/packages/engine/src/rfc/types.ts
+++ b/packages/engine/src/rfc/types.ts
@@ -1,0 +1,18 @@
+export type HashKey = string;
+
+export interface DiagnosticJsonMessage {
+	code: number;
+	category: string;
+}
+export interface DiagnosticMatcher extends DiagnosticJsonMessage {
+	hashKey: string;
+	message: string;
+	matcher: RegExp;
+	parameters: string[];
+}
+export interface Diagnostic extends DiagnosticJsonMessage {
+	hashKey: HashKey;
+	message: string;
+	matched: string;
+	parameters: string[];
+}


### PR DESCRIPTION
# Description

See: #16 (slightly outdated)
Please ignore my formatting style 🤣 and the fact that all code is under `rfc/` dir - pushing just as is locally implemented 🙈.
The point of this PR is to demonstrate and talk about how hashing of diagnostic messages can improve matching performance to `O(1)` in most cases and `O(~3)` at worst which is still better than iterating over all +1000 to find a match.

## What?

Everything is achieves by `ConvertDiagnosticMessageToHashKey` which strips all possible type information from a diagnostic message including some edge cases such as primitive types of this sort:
```ts
type E = '' | "\"" | ' w a "string"' | '\''
```
that are reduced to simple `'T'`. Here the actual types do not really matter, the purpose is to have all messages to be able to be hashable.

There are about ~30 diagnostic which have hash collisions because once type information is stripped, a few of them look-alike. However, this is fine because the hash map contains not a single value but an array of same-hash diagnostics that can be matched against. Iterating over 1-2 extra diagnostic to find a match is still faster than going over all +1000.

There are a few cases that are not covered such as this one:
```
Generic type 'T' requires between 1 and 2 type arguments.
```
But that's fairly simple to support. (existing code in repo currently doesn't handle this case either)

I hope my verbose naming of variables, functions, and types helps to convey what it does.

Thoughts? 😄 