### PR TITLE
Create list of untranslated errors as `TRANSLATION_STATUS.md` with GH Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,15 @@ jobs:
         with:
           name: VSCode Preview VSIX
           path: 'apps/vscode/*.vsix'
+  
+  generate-status-md:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn translation-status
+    

--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -1,0 +1,15 @@
+name: Repo
+on: push
+
+jobs:
+  generate-status-md:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          cache: 'yarn'
+      - run: yarn
+      - run: yarn translation-status
+    

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,9 @@ yarn dev # This will run the next app
 
 You'll find all of the errors' translations at `packages/engine/errors` and they follow the following conventions:
 
-- Every file must be named with its error code: `<code>.md`
+> 💡 Hint: You can find a list of untranslated errors in [`TRANSLATION_STATUS.md`](https://github.com/mattpocock/ts-error-translator/blob/main/packages/engine/src/TRANSLATION_STATUS.md)
 
-> 💡 Hint: To find the code for the error you're looking for, have a look inside [`tsErrorMessages.json`](https://github.com/mattpocock/ts-error-translator/blob/main/packages/engine/src/tsErrorMessages.json),
-> or check your console, you'll see this formatting `error TS<code>: <msg>`.
+- Every file must be named with its error code: `<code>.md`
 
 - You can follow our template by running the following command. This will write an example file at `packages/engine/errors/<code>.md` with placeholders on how the explanation should be written.
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev --parallel",
     "translate": "ts-node -T scripts/translate.ts",
+    "translation-status": "ts-node -T scripts/translation-status.ts",
     "lint": "turbo run lint",
     "test": "turbo run test",
     "extension:build": "yarn workspace ts-error-translator compile",

--- a/packages/engine/errors/2326.md
+++ b/packages/engine/errors/2326.md
@@ -1,6 +1,0 @@
----
-original: "Types of parameters '{0}' and '{1}' are incompatible."
-excerpt: "Simplified version of the error message (Use 'you' as the pronoun because it feels friendly)"
----
-
-More details, reproducible examples for the error and How the error should be fixed.

--- a/scripts/translation-status.ts
+++ b/scripts/translation-status.ts
@@ -9,7 +9,7 @@ const template = (translationStatusLists: TSErrorListByTranslationStatus) =>
   `
 # Translation Statuses
 
-This file was generated with a GitHub Action and lists the translations status of each TypeScript error.
+This file was generated with a GitHub Action and lists the translation status of each TypeScript error.
 
 ## Need Translation
 

--- a/scripts/translation-status.ts
+++ b/scripts/translation-status.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import {
+  getErrorListsByTranslationStatus,
+  TSErrorListByTranslationStatus,
+  TSErrorType,
+} from './utils/translations';
+
+const template = (translationStatusLists: TSErrorListByTranslationStatus) =>
+  `
+# Translation Statuses
+
+This file was generated with a GitHub Action and lists the translations status of each TypeScript error.
+
+## Need Translation
+
+${translationStatusLists.needTranslation
+  .map(makeErrorStatusMarkdown)
+  .join('\n')}
+
+## Translated
+
+${translationStatusLists.translated.map(makeErrorStatusMarkdown).join('\n')}
+
+`.trim();
+
+function writeMarkdownFile(
+  translationStatuses: TSErrorListByTranslationStatus,
+) {
+  fs.writeFileSync('TRANSLATION_STATUS.md', template(translationStatuses));
+}
+
+function makeErrorStatusMarkdown(tsError: TSErrorType) {
+  return `- (${tsError.code}) ${tsError.message}`;
+}
+
+writeMarkdownFile(getErrorListsByTranslationStatus());

--- a/scripts/utils/translations.ts
+++ b/scripts/utils/translations.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import { logger } from './logger';
+import tsErrorJSON from '../../packages/engine/src/tsErrorMessages.json';
+
+export type TSErrorType = {
+  code: number;
+  message: string;
+  category: string;
+};
+
+export type TSErrorListByTranslationStatus = {
+  needTranslation: TSErrorType[];
+  translated: TSErrorType[];
+};
+
+export function getAllErrorsByMessage() {
+  return tsErrorJSON;
+}
+
+export function getTranslatedErrorCodes(): Set<number> {
+  const translatedErrorCodes = new Set<number>();
+
+  fs.readdirSync('packages/engine/errors').forEach((filename) => {
+    const [name, extension] = filename.split('.');
+
+    if (extension.toLowerCase() !== 'md') {
+      logger.info(`Skipping ${filename} because extension is not .md`);
+    } else {
+      translatedErrorCodes.add(Number(name));
+    }
+  });
+
+  return translatedErrorCodes;
+}
+
+export function getErrorListsByTranslationStatus(): TSErrorListByTranslationStatus {
+  const translatedErrorCodes = getTranslatedErrorCodes();
+  const allErrorsByMessage = getAllErrorsByMessage();
+
+  return Object.entries(allErrorsByMessage).reduce(
+    (acc, [message, { category, code }]) => {
+      if (translatedErrorCodes.has(code)) {
+        acc.translated.push({ message, category, code });
+      } else {
+        acc.needTranslation.push({ message, category, code });
+      }
+      return acc;
+    },
+    { translated: [], needTranslation: [] } as TSErrorListByTranslationStatus,
+  );
+}


### PR DESCRIPTION
Adds a script that generates a markdown file `TRANSLATION_STATUS.md` with a list of untranslated errors. 

This will (hopefully) make it easier for contributors to shop for a error code they can translate.

## Notes

- I don't think I have the GitHub action set up correctly yet; may need a little assist there since it is not running on my fork
- I put some of the code in `scripts/utils/translations.ts` because it might be useful for other similar tasks like adding a repo badge with translation progress
- It's intimidating writing code for this repo
- This is my first OSS contribution 😄 