### PR TITLE
Code Action / Quick Fix: "Add missing type properties"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
 			"outFiles": [
 				"${workspaceFolder}/apps/vscode/out/**/*.js"
 			],
-			"preLaunchTask": "npm: extension:build"
+			"preLaunchTask": "npm: extension:build:debug"
 		},
 		{
 			"name": "Extension Tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
 	"tasks": [
 		{
 			"type": "npm",
-			"script": "extension:build",
+			"script": "extension:build:debug",
 			"isBackground": true,
 			"presentation": {
 				"reveal": "never"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
-<img src="https://raw.githubusercontent.com/mattpocock/ts-error-translator/main/assets/screenshot.png" alt="An improved error message showing in a VSCode document" />
+> This is a fork from [mattpocock/ts-error-translator](https://github.com/mattpocock/ts-error-translator).
 
-# TypeScript Error Translator
+### Fork Info
 
-Confused by TypeScript errors? Translate them into human-readable language right in your IDE.
+This fork includes the code action `Add missing type parameters` as a `Quick Fix` for the errors `2345, 2739, 2741`.
 
-[Download our VSCode Extension](https://marketplace.visualstudio.com/items?itemName=mattpocock.ts-error-translator)
+It allows quickly populating an object with all it's required parameters.
 
-Want a preview? Check out our [online playground](https://ts-error-translator.vercel.app/).
-
-## Contributing
-
-TypeScript has 1000-2000 error messages for us to translate, so we'll need some help tackling them all. Contributions are highly welcome!
-
-Read the [Contributing guide](https://github.com/mattpocock/ts-error-translator/blob/main/CONTRIBUTING.md) to get started.
+![add_missing_type_params](https://user-images.githubusercontent.com/2349393/166653049-0babbb29-8aa8-4ef5-99e6-bf83d4489541.gif)

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -54,6 +54,7 @@
   "scripts": {
     "vscode:prepublish": "yarn run compile",
     "compile": "yarn bundle-errors && esbuild --bundle --platform=\"node\" src/extension.ts --outfile=out/extension.js --external:vscode --format=cjs",
+    "compile:debug": "yarn bundle-errors && esbuild --bundle --platform=\"node\" src/extension.ts --sourcemap --outfile=out/extension.js --external:vscode --format=cjs",
     "bundle-errors": "node -r esbuild-register src/bundleErrors.ts",
     "pretest": "yarn run compile && yarn run lint",
     "lint": "tsc",

--- a/apps/vscode/src/codeActions/addMissingTypeProps.ts
+++ b/apps/vscode/src/codeActions/addMissingTypeProps.ts
@@ -1,0 +1,144 @@
+import * as vscode from 'vscode';
+import XRegExp from 'xregexp';
+export const COMMAND = 'ts-fill-object.command';
+
+export class AddMissingTypeProps implements vscode.CodeActionProvider {
+
+	public static readonly providedCodeActionKinds = [
+		vscode.CodeActionKind.QuickFix
+	];
+
+	private static CODES = [2345, 2739, 2741];
+
+	provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.CodeAction[] {
+		return context.diagnostics
+			.filter(diagnostic => AddMissingTypeProps.CODES.includes(diagnostic.code as number))
+			.map(diagnostic => this.createCommandCodeAction(diagnostic));
+	}
+
+	private createCommandCodeAction(diagnostic: vscode.Diagnostic): vscode.CodeAction {
+		const action = new vscode.CodeAction(
+			'Add missing type properties',
+			vscode.CodeActionKind.QuickFix
+		);
+		action.command = {
+			command: COMMAND,
+			title: 'Fill object with missing type properties',
+			tooltip: 'This will add undefined properties to the object.',
+			arguments: [diagnostic]
+		};
+		action.diagnostics = [diagnostic];
+		action.isPreferred = true;
+		return action;
+	}
+
+	/* Code Action Implementation */
+
+	static Run(diagnostic: vscode.Diagnostic) {
+		// Error codes:
+		// 2345: The error is raised on the object itself
+		// 2739: The error is raised on the parameter name (in case of nested objects)
+		// 2741: The error is raised on the nested parameter name (in case of doubly nested objects)
+		
+		let editor = vscode.window.activeTextEditor;
+		if (!editor) return;
+
+		let text = '';
+		let range = diagnostic.range;
+
+		if (diagnostic.code === 2345) {
+			text = editor.document.getText(diagnostic.range);
+		}
+		else {
+			let obj = ParseObjectFromParamName(editor, diagnostic.range);
+			if (!obj) return;
+			text = obj.text;
+			range = obj.range;
+		}
+
+		let info = GetObjInfo(text, range.start, diagnostic.code === 2345);
+		let params = ExtractParams(diagnostic.message);
+
+		let params_text = params.map(p =>
+			(info.multiline?'\n':'') + ' '.repeat(info.offset) + p + ': ?'
+		).join(',');
+
+		let ending = ' ';
+		if (info.multiline) {
+			if (diagnostic.code === 2345) ending = '\n';
+			else ending = '\n'+' '.repeat(diagnostic.range.start.character);
+		}
+		let comma = info.empty?'':',';
+
+		text = text.replace(/{(.*?),?( *\n*)*}$/s, `{$1${comma}${params_text}${ending}}`);
+		editor.edit((edit: vscode.TextEditorEdit) => {
+			edit.replace(range, text)
+		})
+	}
+}
+
+function ExtractParams(message: string): string[] {
+	// Message models:
+	// - Property 'name' is missing in type '{}' but required in type '{ name: string; }'
+	// - Type '{}' is missing the following properties from type '{ name: string; age: number; }': name, age
+	
+	let params: string[] = [];
+	let single = /Property '(.*)' is missing/.exec(message);
+	if (single) params.push(single[1]);
+	else {
+		let many = /Type '.*' is missing .*: (.*)/.exec(message);
+		if (many) params.push(...many[1].split(/, ?/));
+	}
+	return params;
+}
+
+function GetTextUntilEOF(editor: vscode.TextEditor, start: vscode.Position) {
+	let last_line = editor.document.lineAt(editor.document.lineCount - 1);
+	return editor.document.getText(new vscode.Range(start, last_line.range.end));
+}
+
+function StringRange(start: vscode.Position, string: string) {
+	let lines = string.split('\n');
+	let n = lines.length-1;
+	let last_line = lines[n];
+
+	let end_char = last_line.length;
+	if (n == 0) end_char += start.character;
+
+	return new vscode.Range(
+		start,
+		new vscode.Position(start.line + n, end_char)
+	)
+}
+
+function ParseObjectFromParamName(editor: vscode.TextEditor, range: vscode.Range) {
+	let text = GetTextUntilEOF(editor, range.start);
+	
+	let param = text.match(/(.*?):.*?{/s);
+	let param_name_range = StringRange(range.start, param![0]);
+
+	let obj = XRegExp.matchRecursive(text,'{','}');
+	text = '{' + obj[0] + '}';
+
+	let obj_start = param_name_range.end.translate(undefined,-1);
+	let obj_range = StringRange(obj_start, text);
+
+	return {text, range: obj_range};
+}
+
+function GetObjInfo(text: string, start: vscode.Position, root: boolean) {
+	let empty = text.match(/{(\n* *)*}/) != null;
+	let multiline = text.match(/{ *\n/) != null;	
+	let offset = root ? 4 : 1;
+	
+	if (empty) {
+		multiline = true;
+		if (!root) offset = (Math.ceil(start.character/4)-1)*4;
+	}
+	else if (multiline) {
+		let first_param_offset = /( *)\S+:/.exec(text);
+		offset = first_param_offset ? first_param_offset[1].length : 0;
+	}
+
+	return { empty, multiline, offset }
+}

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { AddMissingTypeProps, COMMAND as FILLOBJECT_COMMAND } from './codeActions/addMissingTypeProps';
 import { humaniseDiagnostic } from './humaniseDiagnostic';
 import { Options } from './types';
 
@@ -88,6 +89,22 @@ export function activate(context: vscode.ExtensionContext) {
       });
     }),
   );
+
+  context.subscriptions.push(
+		vscode.languages.registerCodeActionsProvider(
+      {
+        language: 'typescript',
+      },
+      new AddMissingTypeProps(),
+      {
+			  providedCodeActionKinds: AddMissingTypeProps.providedCodeActionKinds
+		  }
+    )
+	);
+
+	context.subscriptions.push(
+		vscode.commands.registerCommand(FILLOBJECT_COMMAND, AddMissingTypeProps.Run)
+	);
 }
 
 // this method is called when your extension is deactivated

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "extension:build": "yarn workspace ts-error-translator compile",
+    "extension:build:debug": "yarn workspace ts-error-translator compile:debug",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky install",
     "release": "(cd apps/vscode && (npx vsce publish || true)) && (cd apps/vscode && npx ovsx publish $(find . -iname *.vsix)) && node ./scripts/tag-extension.js"


### PR DESCRIPTION
Hi! This vscode extension is exactly what I've been looking for in a while, thank you for putting it together.

One of the main reasons I need it is to make the initialization of typed objects easier, by looking at the pretty-printed error to know which property is missing.
However, I've realized a "Quick Fix" could further improve the UX, so here's a beta version.

![add_missing_type_params0](https://user-images.githubusercontent.com/2349393/166654330-1c3a68bc-65ba-4966-9d84-6d23aefd3504.gif)

It allows a smooth typing flow by using `Ctrl + .` to populate newly created objects:

![add_missing_type_params](https://user-images.githubusercontent.com/2349393/166654106-162d0bba-2932-40c1-a4b8-0962dffd3335.gif)

