### PR TITLE
Add error 1163

### DIFF
--- a/packages/engine/errors/1003.md
+++ b/packages/engine/errors/1003.md
@@ -3,4 +3,4 @@ original: 'Identifier expected.'
 excerpt: "Your code doesn't comply with the syntax rules of the TypeScript language"
 ---
 
-This means that your syntax is wrong and simply the compiler can't tokenize your code properly.
+This means that your syntax is wrong and the compiler simply can't tokenize your code properly.

--- a/packages/engine/errors/1163.md
+++ b/packages/engine/errors/1163.md
@@ -1,0 +1,6 @@
+---
+original: "A 'yield' expression is only allowed in a generator body."
+excerpt: "Yield expressions must be used within a generator function"
+---
+
+If you want to use the functionality provided by yield, you should turn the enclosing function into a generator by adding an asterisk (*) next to the function name. Otherwise, you can remove the yield statement altogether.


### PR DESCRIPTION
Added error translation for 1163 (A 'yield' expression is only allowed in a generator body.)
Minor grammar improvement for 1003