### PR TITLE
Improve 1003 excerpt and description

### DIFF
--- a/packages/engine/errors/1003.md
+++ b/packages/engine/errors/1003.md
@@ -1,6 +1,22 @@
 ---
 original: 'Identifier expected.'
-excerpt: "Your code doesn't comply with the syntax rules of the TypeScript language"
+excerpt: "I was expecting a name but none was provided."
 ---
 
-This means that your syntax is wrong and simply the compiler can't tokenize your code properly.
+You are using a keyword that expects to be followed by a **variable, type, interface, class, function,** or **property** name but none was provided in the location were I'm pointing at.
+
+The following examples are invalid:
+
+```ts
+function () {}
+type Foo = (typeof);
+Number.;
+```
+
+Providing a valid name (identifier) in the location where I'm pointing at fixes the issue:
+
+```ts
+function bar() {}        // function name added after 'function'
+type Foo = (typeof bar); // variable name added after 'typeof'
+Number.MAX_SAFE_INTEGER; // property name added after '.'
+```


### PR DESCRIPTION
# Description

The current excerpt and description for 1003 are ambiguous and not very helpful to understand how to solve the issue.

"Identifier" is a global term that - in compilers - always refer to a token name that is used to identify a **thing**. In CSS, a CSS variable is an identifier; in JS, a function name, a variable name, a class name, etc are identifiers.

If users often ask what this error means, it's because they're not familiar with the term "identifier", so I believe making it explicit in the excerpt and description that an "identifier" is just a fancy name for a "name", it'd help them understand better what the issue is and they'll most likely remember it the next time another TS error pops up mentioning the term "identifier".

### Screenshot

<img width="560" alt="Screen Shot 2022-05-05 at 00 27 04" src="https://user-images.githubusercontent.com/1407526/166727100-abbef2df-28f8-4a9b-987d-886b4bcd72ef.png">
