### PR TITLE
2761: Type '{0}' has no construct signatures.

### DIFF
--- a/.changeset/bright-dots-design.md
+++ b/.changeset/bright-dots-design.md
@@ -1,0 +1,5 @@
+---
+"@ts-error-messages/engine": patch
+---
+
+Add translation for 2761

--- a/packages/engine/errors/2761.md
+++ b/packages/engine/errors/2761.md
@@ -1,6 +1,29 @@
 ---
 original: "Type '{0}' has no construct signatures."
-excerpt: "You can't use `new` on '{0}' - it doesn't look like it's possible to me."
+excerpt: "Type '{0}' is not a class."
 ---
 
-TODO
+You cannot use the `new` keyword because type `{0}` is neither a class nor a function constructor. For example:
+
+```ts
+interface Foo {
+  bar: string;
+}
+function test(MyFoo: Foo) {
+  const instance = new MyFoo("");
+}
+```
+
+Here using the `new` keyword is a mistake because the type of `myFoo` parameter is `Foo` which describes an object type. The following examples are valid cases I'd accept:
+
+```ts
+class Foo { }
+interface Bar {
+  new(): Record<string, any>
+}
+
+function test(MyFoo: typeof Foo, MyBar: Bar) {
+  const instanceOfFoo = new MyFoo()
+  const instanceOfBar = new MyBar()
+}
+```


### PR DESCRIPTION
# Description

Diagnostic: `Type '{0}' has no construct signatures.`

Add a description and change excerpt to better describe the problem.

I used `Type '{0}' is not a class.` as excerpt because that's the most common case but the description expands to describe that it also refers to function constructors.

Technically, a function that returns `void` is a valid construct signature (no error) but that's as useless as it gets because the instance of such constructor is always `any` so it has absolutely no value on explaining it here at all.