### PR TITLE
Removed whitespace from body-and-tldr display mode

### DIFF
--- a/.changeset/yellow-crabs-compete.md
+++ b/.changeset/yellow-crabs-compete.md
@@ -1,0 +1,5 @@
+---
+"ts-error-translator": minor
+---
+
+Removed whitespace from body-and-tldr display mode, making things more compact and easier to scan.

--- a/apps/vscode/src/humaniseDiagnostic.ts
+++ b/apps/vscode/src/humaniseDiagnostic.ts
@@ -69,11 +69,9 @@ export const humaniseDiagnostic = (
         case 'body-and-tldr':
           {
             errorBodies.push(
-              linkToTranslation,
-              `### TL;DR`,
-              excerpt,
-              `### Full Translation`,
+              `**Translation**: ${excerpt}`,
               body,
+              linkToTranslation,
             );
           }
           break;


### PR DESCRIPTION
![Screenshot 2022-05-10 at 10 28 54](https://user-images.githubusercontent.com/28293365/167597875-ad266a98-75db-46b5-be29-ba3dd10a3833.png)

When the user selects BOTH the TLDR and the translation to display, it displays as above.

Fixes #82 