### PR TITLE
Add support for Astro files

### DIFF
--- a/.changeset/shiny-eagles-attack.md
+++ b/.changeset/shiny-eagles-attack.md
@@ -1,0 +1,5 @@
+---
+"ts-error-translator": minor
+---
+
+Add support for Astro files

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -28,7 +28,8 @@
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
     "onLanguage:vue",
-    "onLanguage:svelte"
+    "onLanguage:svelte",
+    "onLanguage:astro"
   ],
   "main": "./out/extension.js",
   "browser": "./out/extension.js",

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -75,6 +75,12 @@ export function activate(context: vscode.ExtensionContext) {
       },
       hoverProvider,
     ),
+    vscode.languages.registerHoverProvider(
+      {
+        language: 'astro',
+      },
+      hoverProvider,
+    ),
   );
 
   context.subscriptions.push(


### PR DESCRIPTION
Hello! I'm Erika from the [Astro](https://astro.build/) team

I have a lot of personal thoughts (all very positive!) about this project but I'll keep it short for this PR: This project is so so cool, especially for JSX where the errors are so insanely verbose (yet at the same time, not super informative? :sweat_smile:) and I'd love to have Astro support for it, so here I am

I tested the changes locally and everything seemed to work as expected: 
![image](https://user-images.githubusercontent.com/3019731/167672625-cf6445a3-6ee3-4ab6-8f7d-d56d309197bf.png)

Do not hesitate if there's any additional information needed. I am also completely okay with this being refused if supporting Astro is considered outside the scope of the project, no worries!

Thank you!