### PR TITLE
Fix: 7061 - use double quotes on excerpt

### DIFF
--- a/packages/engine/errors/7061.md
+++ b/packages/engine/errors/7061.md
@@ -1,6 +1,6 @@
 ---
-original: 'A mapped type may not declare properties or methods.'
-excerpt: 'You're trying to create a mapped type with both static and dynamic properties.'
+original: "A mapped type may not declare properties or methods."
+excerpt: "You're trying to create a mapped type with both static and dynamic properties."
 ---
 
 ```ts


### PR DESCRIPTION
I overlooked an unclosed single quote in excerpt in latest PR I merged. This caused the CI to fail when running bundle-errors.

> 'You're (...)

