### PR TITLE
Add 2783: '{0}' is specified more than once, so this usage will be overwritten.

### DIFF
--- a/packages/engine/errors/2783.md
+++ b/packages/engine/errors/2783.md
@@ -3,7 +3,7 @@ original: "'{0}' is specified more than once, so this usage will be overwritten.
 excerpt: "'{0}' will be overwritten by the spread."
 ---
 
-I think you need to reorder the object property assignments, and move the spread first. because what comes first is 'overridden' by what comes later. if you have such assignments:
+I think you need to reorder the object property assignments, and move the spread first. because what comes first is 'overridden' by what comes later. For example if you have such assignments:
 
 ```ts
 const foo = {

--- a/packages/engine/errors/2783.md
+++ b/packages/engine/errors/2783.md
@@ -1,6 +1,6 @@
 ---
 original: "'{0}' is specified more than once, so this usage will be overwritten."
-excerpt: '{0} will be overwritten by the spread.'
+excerpt: "'{0}' will be overwritten by the spread."
 ---
 
 I think you need to reorder the object property assignments, and move the spread first. because what comes first is 'overridden' by what comes later. if you have such assignments:

--- a/packages/engine/errors/2783.md
+++ b/packages/engine/errors/2783.md
@@ -16,7 +16,7 @@ const baz = {
 };
 ```
 
-change it like this:
+You can change it to be like this:
 
 ```ts
 const baz = {

--- a/packages/engine/errors/2783.md
+++ b/packages/engine/errors/2783.md
@@ -16,7 +16,7 @@ const baz = {
 };
 ```
 
-change it to this:
+change it like this:
 
 ```ts
 const baz = {

--- a/packages/engine/errors/2783.md
+++ b/packages/engine/errors/2783.md
@@ -1,0 +1,26 @@
+---
+original: "'{0}' is specified more than once, so this usage will be overwritten."
+excerpt: '{0} will be overwritten by the spread.'
+---
+
+I think you need to reorder the object property assignments, and move the spread first. because what comes first is 'overridden' by what comes later. if you have such assignments:
+
+```ts
+const foo = {
+  bar: 'A',
+};
+
+const baz = {
+  bar: 'B',
+  ...foo,
+};
+```
+
+change it to this:
+
+```ts
+const baz = {
+  ...foo,
+  bar: 'B',
+};
+```

--- a/packages/engine/errors/2783.md
+++ b/packages/engine/errors/2783.md
@@ -3,7 +3,7 @@ original: "'{0}' is specified more than once, so this usage will be overwritten.
 excerpt: "'{0}' will be overwritten by the spread."
 ---
 
-I think you need to reorder the object property assignments, and move the spread first. because what comes first is 'overridden' by what comes later. For example if you have such assignments:
+I think you need to reorder the object property assignments and move the spread first. When spreading, what comes first is 'overridden' by what comes later. For example, if you have assignments like these:
 
 ```ts
 const foo = {


### PR DESCRIPTION
Add ts2783