### PR TITLE
7054: No index signature with a parameter of type '{0}' was found on type '{1}'.

### DIFF
--- a/packages/engine/errors/7054.md
+++ b/packages/engine/errors/7054.md
@@ -1,0 +1,34 @@
+---
+original: "No index signature with a parameter of type '{0}' was found on type '{1}'."
+excerpt: "You are trying to access an object using a key with type 'A,' but I am looking for a property's value type on type 'B.'"
+---
+
+```ts
+type Foo = {
+  foo: string;
+};
+
+const foo: Foo = {
+  foo: 'foo',
+};
+
+const getFoo = (key: string) => {
+  return foo[key];
+}; // ❌
+```
+
+To fix this, you can use `keyof`.
+
+```ts
+type Foo = {
+  foo: string;
+};
+
+const foo: Foo = {
+  foo: 'foo',
+};
+
+const getFoo = (key: keyof Foo) => {
+  return foo[key];
+}; // ✅
+```


### PR DESCRIPTION
Error explanation for 7054: No index signature with a parameter of type '{0}' was found on type '{1}'.