### PR TITLE
Error 7008: "Member '{0}' implicitly has an '{1}' type."

### DIFF
--- a/packages/engine/errors/7008.md
+++ b/packages/engine/errors/7008.md
@@ -1,0 +1,26 @@
+---
+original: "Member '{0}' implicitly has an '{1}' type."
+excerpt: "I don't know what type this member is supposed to be. Your tsconfig file says I should throw an error here."
+---
+
+You've likely declared a class, like this:
+
+```ts
+class dog {
+  name;
+  breed?;
+  bark;
+}
+```
+
+I don't know what the members of this class (`name`, `breed`, and `bark`) are. Consider telling me:
+
+```ts
+class dog {
+  name = 'Spot';
+  breed?: string;
+  bark() {
+    console.log('Woof!');
+  }
+}
+```


### PR DESCRIPTION
Hello! I've written an explanation for the following error: "Member '{0}' implicitly has an '{1}' type." In the second example, I made members optional or gave them default values to avoid triggering this error: " Property '{0}' has no initializer and is not definitely assigned in the constructor. (#2564)"

A few questions:
- I struggled to think of a plain-English word to use in place of "class member." Any suggestions?
- It seems like "Your tsconfig file says I should throw an error here" could apply to most TypeScript errors. Should I leave this part out?
- Is there anything else that could be improved or changed?

Thanks for creating this tool - I've recommended it to my colleagues and they're super excited about it.