### PR TITLE
Error 2308: Module {0} has already exported a member named '{1}'

### DIFF
--- a/packages/engine/errors/2308.md
+++ b/packages/engine/errors/2308.md
@@ -1,0 +1,10 @@
+---
+original: "Module {0} has already exported a member named '{1}'. Consider explicitly re-exporting to resolve the ambiguity."
+excerpt: "You are trying to export a member named '{1}' which has already been exported by module '{0}' in this file."
+---
+
+To resolve the ambiguity, you need to explicitly re-export the member with a new alias:
+
+```ts
+export { {1} as foo } from {0};
+```


### PR DESCRIPTION
Error translation and explanation for code 2308 - member already exported