### PR TITLE
Error 2305: Module '{0}' has no exported member '{1}'.

### DIFF
--- a/packages/engine/errors/2305.md
+++ b/packages/engine/errors/2305.md
@@ -1,0 +1,10 @@
+---
+original: "Module '{0}' has no exported member '{1}'."
+excerpt: "I can't find any exported member '{1}' in module '{0}'."
+---
+
+You need to export '{1}' from module {0}.
+
+```ts
+export { {1} };
+```


### PR DESCRIPTION
Error translation and explanation for code 2305 - no exported member