### PR TITLE
Add explain for TS5075 "but 'T' could be instantiated with a different subtype of constraint 'Y'."

### DIFF
--- a/packages/engine/errors/5075.md
+++ b/packages/engine/errors/5075.md
@@ -1,6 +1,48 @@
 ---
 original: "'{0}' is assignable to the constraint of type '{1}', but '{1}' could be instantiated with a different subtype of constraint '{2}'."
-excerpt: "You're passing a type '{0}' into a slot which is too narrow. It could be as wide as anything assignable to '{2}'."
+excerpt: "You're passing a type '{0}' to '{1}'. Although '{0}' and '{1}' both satisfy the requirement '{2}', the actual '{0}' might not be compatible with '{1}', considering they are siblings that both extend from '{2}'.
 ---
 
-TODO
+### Explain
+
+This error might be confusing, let's consider this code:
+
+```ts
+class Base { x = 1 }
+class ChildA extends Base { a = 1 }
+function defaults<T extends Base>(instance: T = new ChildA()): T {
+//                                ~~~~~~~~~~~~~~~~~~~~~~~~~~
+// 'ChildA' is assignable to the constraint of type 'T',
+// but 'T' could be instantiated with a different subtype of constraint 'Base'.
+    return instance
+}
+```
+
+You might wonder why this is problematic, because it works well for you:
+
+```ts
+defaults() // ChildA
+defaults(new Base()) // Base
+```
+
+Those examples look good, but let's consider this code:
+
+```ts
+class ChildB extends Base { x = "" }
+const instance = defaults<ChildB>()
+instance.x.startsWith("")
+```
+
+As you can see, I didn't provide the first argument `instance` into `defaults` (so it will be a `ChildA` in the runtime),
+and I also manually fill the type parameter `T = ChildB`, so `instance` has type `ChildB`.
+
+When I try to access `instance.x.startsWith` (it is defined on `ChildB`, but not on `ChildA`), it becomes a runtime error.
+
+> Cannot read properties of undefined (reading 'startsWith').
+
+Because there is no way in TypeScript to
+
+- disallow filling type parameters manually (which means you must rely the type inference)
+- disallow creating a new subtype of `Base` (declare that `Base` only have the following "blessed" subtypes `ChildA`)
+
+By the reasons explained above, I cannot let this code pass the check.


### PR DESCRIPTION
---
original: "'{0}' is assignable to the constraint of type '{1}', but '{1}' could be instantiated with a different subtype of constraint '{2}'."
excerpt: "You're passing a type '{0}' to '{1}'. Although '{0}' and '{1}' both satisfy the requirement '{2}', the actual '{0}' might not be compatible with '{1}', considering they are siblings that both extend from '{2}'.
---

### Explain

This error might be confusing, let's consider this code:

```ts
class Base { x = 1 }
class ChildA extends Base { a = 1 }
function defaults<T extends Base>(instance: T = new ChildA()): T {
//                                ~~~~~~~~~~~~~~~~~~~~~~~~~~
// 'ChildA' is assignable to the constraint of type 'T',
// but 'T' could be instantiated with a different subtype of constraint 'Base'.
    return instance
}
```

You might wonder why this is problematic, because it works well for you:

```ts
defaults() // ChildA
defaults(new Base()) // Base
```

Those examples look good, but let's consider this code:

```ts
class ChildB extends Base { x = "" }
const instance = defaults<ChildB>()
instance.x.startsWith("")
```

As you can see, I didn't provide the first argument `instance` into `defaults` (so it will be a `ChildA` in the runtime),
and I also manually fill the type parameter `T = ChildB`, so `instance` has type `ChildB`.

When I try to access `instance.x.startsWith` (it is defined on `ChildB`, but not on `ChildA`), it becomes a runtime error.

> Cannot read properties of undefined (reading 'startsWith').

Because there is no way in TypeScript to

- disallow filling type parameters manually (which means you must rely on the type inference)
- disallow creating a new subtype of `Base` (declare that `Base` only has the following "blessed" subtypes `ChildA`)

By the reasons explained above, I cannot let this code pass the check.