### PR TITLE
Error 1385: Function type notation must be parenthesized when used in a union type.

### DIFF
--- a/packages/engine/errors/1385.md
+++ b/packages/engine/errors/1385.md
@@ -1,0 +1,24 @@
+---
+original: 'Function type notation must be parenthesized when used in a union type.'
+excerpt: "You can only use parenthesized function type notation in a union type."
+---
+
+### Examples
+
+You can't use function type notation in union type like this:
+
+```ts
+type fancyString = {
+  fancyWord: string | () => string;
+}
+// 👎
+```
+
+Instead, why don't you parenthesize function like this?:
+
+```ts
+type fancyString = {
+  fancyWord: string | (() => string);
+}
+// ✅
+```


### PR DESCRIPTION
Error translation and explanation for code **1385**
- Function type notation must be parenthesized when used in a union type.