### PR TITLE
Error 7053: Element implicitly has an 'any' type because expression of type '{0}' can't be used to index type '{1}'.

### DIFF
--- a/packages/engine/errors/7053.md
+++ b/packages/engine/errors/7053.md
@@ -1,0 +1,26 @@
+---
+original: "Element implicitly has an 'any' type because expression of type '{0}' can't be used to index type '{1}'."
+excerpt: "I'm not sure that 'A' exists in 'B', so I interpret it as 'any'"
+---
+
+You're likely inside a loop, trying to access an object property with a string literal containing an index.
+
+```ts
+interface myObject {
+  value1?: string | undefined
+  value2?: string | undefined
+  value3?: string | undefined
+}
+
+const anObject: myObject = {};
+
+const arr = ['1', '2', '3', '4'];
+
+arr.forEach((index, val) => {
+  anObject[`value${index + 1}`] = val;
+});
+```
+
+But right now, I dont know if the string literal points to an invalid object key, due to the variable being the incrementing index. It could be `anObject.value4` which does not exist on the type.
+
+The reason this is showing as an error is because you've got `"strict": true` in your TS Config.

--- a/packages/engine/errors/7053.md
+++ b/packages/engine/errors/7053.md
@@ -9,18 +9,25 @@ You're likely inside a loop, trying to access an object property with a string l
 interface myObject {
   value1?: string | undefined
   value2?: string | undefined
-  value3?: string | undefined
 }
 
 const anObject: myObject = {};
 
-const arr = ['1', '2', '3', '4'];
+const arr = ['foo', 'bar', 'baz'];
 
-arr.forEach((index, val) => {
-  anObject[`value${index + 1}`] = val;
+arr.forEach((val, index) => {
+  anObject[`value${index + 1}`] = val; ❌
 });
 ```
 
-But right now, I dont know if the string literal points to an invalid object key, due to the variable being the incrementing index. It could be `anObject.value4` which does not exist on the type.
+But right now, I dont know if the string literal points to an invalid object key, due to the variable being the incrementing index. It could be `anObject.value3` which does not exist on the type.
+
+```ts
+type T = keyof typeof anObject;
+
+arr.forEach((val, index) => {
+  anObject[(`value${index + 1}` as T)] = val; ✅
+});
+```
 
 The reason this is showing as an error is because you've got `"strict": true` in your TS Config.


### PR DESCRIPTION
I'm not completely sure that my translation covers all cases for this error, however it describes exactly what **I needed**, when I faced it. 

And I wanted to contribute to the project 🙏🏻