### PR TITLE
translation for error 2790: 'The operand of a 'delete' operator must be optional.'

### DIFF
--- a/packages/engine/errors/2790.md
+++ b/packages/engine/errors/2790.md
@@ -1,0 +1,51 @@
+---
+original: "The operand of a 'delete' operator must be optional."
+excerpt: "The property you are trying to delete is not optional in the type interface. Try using a partial type or making it an optional property in the original interface."
+---
+
+This is because you are trying to delete the property of a type that is declared as a required property in the interface.
+
+For example:
+
+```ts
+export interface Person {
+  name: string;
+  age: number;
+}
+
+const myPerson: Person = {
+  name: 'Law',
+  age: 34
+};
+
+delete myPerson.age;
+```
+
+This causes the error 2790 as age is required by the Person interface.
+
+You can either use a partial type:
+
+```ts
+const myPerson: Partial<Person> = {
+  name: 'Law',
+  age: 34
+};
+
+delete myPerson.age;
+```
+
+or adjust the interface so that the property is optional:
+
+```ts
+export interface Person {
+  name: string;
+  age?: number;
+}
+
+const myPerson: Person = {
+  name: 'Law',
+  age: 34
+};
+
+delete myPerson.age;
+```


### PR DESCRIPTION
translation for error 2790: 'The operand of a 'delete' operator must be optional.'