### PR TITLE
Display button to open an issue when no errors are found

### DIFF
--- a/.changeset/purple-planets-sell.md
+++ b/.changeset/purple-planets-sell.md
@@ -1,0 +1,7 @@
+---
+"@ts-error-messages/app": feat
+"@ts-error-messages/engine": patch
+---
+
+- Display button to open a new issue when no errors are found
+- Make submit button disabled when there is no message

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/new_typescript_error.yml
+++ b/.github/ISSUE_TEMPLATE/new_typescript_error.yml
@@ -1,0 +1,23 @@
+name: New TypeScript Error
+description: Report a TypeScript error message that we don't currently understand
+labels: [Unknown Error]
+body:
+  - type: textarea
+    id: typescript_error
+    attributes:
+      label: Error message
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: typescript_version
+    attributes:
+      label: TypeScript version
+    validations:
+      required: true
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional info
+    validations:
+      required: false

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -155,7 +155,7 @@ export default function Web(props: Props) {
                           <a
                             href="https://github.com/mattpocock/ts-error-translator/blob/main/CONTRIBUTING.md"
                             target="_blank"
-                            rel="noreferrer"
+                            rel="noreferrer noopener"
                           >
                             Add a translation
                           </a>

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -7,23 +7,34 @@ import {
   compressToEncodedURIComponent,
   decompressFromEncodedURIComponent,
 } from 'lz-string';
-import { GetServerSidePropsContext } from 'next';
+import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import * as path from 'path';
-import React from 'react';
+import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { z } from 'zod';
 
-export default function Web(props: { error: string; errors: ErrorInfo[] }) {
+type Result = { type: 'none' } | {
+  type: 'errors',
+  errors: ErrorInfo[]
+}
+
+type Props = {
+  result: Result,
+  error: string,
+}
+
+export default function Web(props: Props) {
   const router = useRouter();
+  const [inputContainsText, setInputContainsText] = useState(!!props.error);
 
-  const firstExcerpt = props.errors[0]?.improvedError?.excerpt;
-  const firstErrorCode = props.errors[0]?.code;
+  const firstError = props.result.type === 'errors' ? props.result.errors[0] ?? null : null;
+  const firstExcerpt = firstError?.improvedError?.excerpt ?? null;
+  const firstErrorCode = firstError?.code ?? null;
 
-  const title = `TypeScript Error Translator${
-    firstErrorCode ? ` | Code #${firstErrorCode}` : ''
-  }`;
+  const title = `TypeScript Error Translator${firstErrorCode ? ` | Code #${firstErrorCode}` : ''
+    }`;
 
   return (
     <>
@@ -96,63 +107,67 @@ export default function Web(props: { error: string; errors: ErrorInfo[] }) {
               name="error"
               autoFocus
               defaultValue={props.error}
+              onChange={(e) => setInputContainsText(!!e.target.value)
+              }
             ></textarea>
             <div>
-              <button className="px-6 py-2 font-semibold tracking-tight text-white rounded from-purple-500 to-indigo-600 bg-gradient-to-r focus:outline-none focus:ring-4 ring-yellow-400">
+              <button disabled={!inputContainsText} className="px-6 py-2 font-semibold tracking-tight text-white rounded from-purple-500 to-indigo-600 bg-gradient-to-r focus:outline-none focus:ring-4 ring-yellow-400 disabled:bg-slate-300 disabled:bg-none disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none">
                 Submit your Error
               </button>
             </div>
           </form>
         </div>
 
-        <div className="max-w-2xl mx-auto space-y-16 text-xl leading-relaxed text-gray-800">
-          {props.errors.map((error, index, array) => {
-            return (
-              <div key={index}>
-                <div className="prose prose-code:before:hidden prose-code:after:hidden">
-                  {/* <span className="inline-block px-2 py-1 mb-2 text-xs text-indigo-900 bg-indigo-100 rounded">
-                  #{error.code}
-                </span> */}
-                  <h1>Error #{array.length - index}</h1>
-                  <div className="relative p-4 py-3 font-mono text-sm leading-relaxed text-gray-100 bg-gray-800 rounded">
-                    {error.parseInfo.rawError}
+        {props.result.type === 'errors' && (
+          <div className="max-w-2xl mx-auto space-y-16 text-xl leading-relaxed text-gray-800">
+            {props.result.errors.map((error, index, array) => {
+              return (
+                <div key={index}>
+                  <div className="prose prose-code:before:hidden prose-code:after:hidden">
+                    {/* <span className="inline-block px-2 py-1 mb-2 text-xs text-indigo-900 bg-indigo-100 rounded">
+                    #{error.code}
+                  </span> */}
+                    <h1>Error #{array.length - index}</h1>
+                    <div className="relative p-4 py-3 font-mono text-sm leading-relaxed text-gray-100 bg-gray-800 rounded">
+                      {error.parseInfo.rawError}
+                    </div>
+                    {error.improvedError && (
+                      <>
+                        <h2>Translation</h2>
+                        <div className="p-4 py-3 font-light text-gray-100 bg-gray-800 rounded prose-code:text-white prose-p:m-0">
+                          <ReactMarkdown>
+                            {error.improvedError.excerpt}
+                          </ReactMarkdown>
+                        </div>
+                        <h2>Explanation</h2>
+                        <ReactMarkdown>{error.improvedError?.body}</ReactMarkdown>
+                      </>
+                    )}
+                    {!error.improvedError && (
+                      <>
+                        <h2>Translation</h2>
+                        <p>
+                          Could not find a translation for error code{' '}
+                          <span className="font-semibold">#{error.code}</span>:
+                        </p>
+                        <code>{error.error}</code>
+                        <p>
+                          <a
+                            href="https://github.com/mattpocock/ts-error-translator/blob/main/CONTRIBUTING.md"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            Add a translation
+                          </a>
+                        </p>
+                      </>
+                    )}
                   </div>
-                  {error.improvedError && (
-                    <>
-                      <h2>Translation</h2>
-                      <div className="p-4 py-3 font-light text-gray-100 bg-gray-800 rounded prose-code:text-white prose-p:m-0">
-                        <ReactMarkdown>
-                          {error.improvedError.excerpt}
-                        </ReactMarkdown>
-                      </div>
-                      <h2>Explanation</h2>
-                      <ReactMarkdown>{error.improvedError?.body}</ReactMarkdown>
-                    </>
-                  )}
-                  {!error.improvedError && (
-                    <>
-                      <h2>Translation</h2>
-                      <p>
-                        Could not find a translation for error code{' '}
-                        <span className="font-semibold">#{error.code}</span>:
-                      </p>
-                      <code>{error.error}</code>
-                      <p>
-                        <a
-                          href="https://github.com/mattpocock/ts-error-translator/blob/main/CONTRIBUTING.md"
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Add a translation
-                        </a>
-                      </p>
-                    </>
-                  )}
                 </div>
-              </div>
-            );
-          })}
-        </div>
+              );
+            })}
+          </div>
+        )}
       </div>
     </>
   );
@@ -162,31 +177,33 @@ const Query = z.object({
   error: z.string().optional(),
 });
 
-export const getServerSideProps = (ctx: GetServerSidePropsContext) => {
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx: GetServerSidePropsContext) => {
   const query = Query.parse(ctx.query);
   if (query.error) {
     const decodedError = decompressFromEncodedURIComponent(query.error)!;
     return {
       props: {
-        errors: parseErrors(decodedError)
-          .reverse()
-          .map((error): ErrorInfo => {
-            return {
-              ...error,
-              improvedError: getImprovedMessageFromMarkdown(
-                path.resolve(process.cwd(), '../../packages/engine/errors'),
-                error.code,
-                error.parseInfo.items,
-              ),
-            };
-          }),
+        result: {
+          type: 'errors', errors: parseErrors(decodedError)
+            .reverse()
+            .map((error): ErrorInfo => {
+              return {
+                ...error,
+                improvedError: getImprovedMessageFromMarkdown(
+                  path.resolve(process.cwd(), '../../packages/engine/errors'),
+                  error.code,
+                  error.parseInfo.items,
+                ),
+              };
+            })
+        },
         error: decodedError,
       },
     };
   }
   return {
     props: {
-      errors: [],
+      result: { type: 'none' },
       error: `Conversion of type 'string' to type 'string[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.`,
     },
   };

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -180,8 +180,8 @@ export default function Web(props: Props) {
                   <h1>Unknown Error</h1>
                   <p>We don&apos;t understand that error yet.</p>
                   <p>
-                    <a href={`https://github.com/mattpocock/ts-error-translator/issues/new?template=new_typescript_error.md&typescript_error=${encodeURIComponent(props.error)}`} target="_blank" rel="noreferrer noopener">
-                      Please let us know by opening an issue.
+                    <a href={`https://github.com/mattpocock/ts-error-translator/issues/new?template=new_typescript_error.yml&typescript_error=${encodeURIComponent(props.error)}`} target="_blank" rel="noreferrer noopener">
+                      Please let us know by opening an issue
                     </a>
                   </p>
                 </div>

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -15,26 +15,30 @@ import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { z } from 'zod';
 
-type Result = { type: 'none' } | {
-  type: 'errors',
-  errors: ErrorInfo[]
-}
+type Result =
+  | { type: 'none' }
+  | {
+      type: 'errors';
+      errors: ErrorInfo[];
+    };
 
 type Props = {
-  result: Result,
-  error: string,
-}
+  result: Result;
+  error: string;
+};
 
 export default function Web(props: Props) {
   const router = useRouter();
   const [inputContainsText, setInputContainsText] = useState(!!props.error);
 
-  const firstError = props.result.type === 'errors' ? props.result.errors[0] ?? null : null;
+  const firstError =
+    props.result.type === 'errors' ? props.result.errors[0] ?? null : null;
   const firstExcerpt = firstError?.improvedError?.excerpt ?? null;
   const firstErrorCode = firstError?.code ?? null;
 
-  const title = `TypeScript Error Translator${firstErrorCode ? ` | Code #${firstErrorCode}` : ''
-    }`;
+  const title = `TypeScript Error Translator${
+    firstErrorCode ? ` | Code #${firstErrorCode}` : ''
+  }`;
 
   return (
     <>
@@ -107,11 +111,13 @@ export default function Web(props: Props) {
               name="error"
               autoFocus
               defaultValue={props.error}
-              onChange={(e) => setInputContainsText(!!e.target.value)
-              }
+              onChange={(e) => setInputContainsText(!!e.target.value)}
             ></textarea>
             <div>
-              <button disabled={!inputContainsText} className="px-6 py-2 font-semibold tracking-tight text-white rounded from-purple-500 to-indigo-600 bg-gradient-to-r focus:outline-none focus:ring-4 ring-yellow-400 disabled:bg-slate-300 disabled:bg-none disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none">
+              <button
+                disabled={!inputContainsText}
+                className="px-6 py-2 font-semibold tracking-tight text-white rounded from-purple-500 to-indigo-600 bg-gradient-to-r focus:outline-none focus:ring-4 ring-yellow-400 disabled:bg-slate-300 disabled:bg-none disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+              >
                 Submit your Error
               </button>
             </div>
@@ -140,7 +146,9 @@ export default function Web(props: Props) {
                           </ReactMarkdown>
                         </div>
                         <h2>Explanation</h2>
-                        <ReactMarkdown>{error.improvedError?.body}</ReactMarkdown>
+                        <ReactMarkdown>
+                          {error.improvedError?.body}
+                        </ReactMarkdown>
                       </>
                     )}
                     {!error.improvedError && (
@@ -166,6 +174,19 @@ export default function Web(props: Props) {
                 </div>
               );
             })}
+            {props.result.errors.length === 0 && (
+              <>
+                <div className="prose prose-code:before:hidden prose-code:after:hidden">
+                  <h1>Unknown Error</h1>
+                  <p>We don&apos;t understand that error yet.</p>
+                  <p>
+                    <a href={`https://github.com/mattpocock/ts-error-translator/issues/new?template=new_typescript_error.md&typescript_error=${encodeURIComponent(props.error)}`} target="_blank" rel="noreferrer noopener">
+                      Please let us know by opening an issue.
+                    </a>
+                  </p>
+                </div>
+              </>
+            )}
           </div>
         )}
       </div>
@@ -177,14 +198,17 @@ const Query = z.object({
   error: z.string().optional(),
 });
 
-export const getServerSideProps: GetServerSideProps<Props> = async (ctx: GetServerSidePropsContext) => {
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  ctx: GetServerSidePropsContext,
+) => {
   const query = Query.parse(ctx.query);
   if (query.error) {
     const decodedError = decompressFromEncodedURIComponent(query.error)!;
     return {
       props: {
         result: {
-          type: 'errors', errors: parseErrors(decodedError)
+          type: 'errors',
+          errors: parseErrors(decodedError)
             .reverse()
             .map((error): ErrorInfo => {
               return {
@@ -195,7 +219,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx: GetServ
                   error.parseInfo.items,
                 ),
               };
-            })
+            }),
         },
         error: decodedError,
       },

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -108,7 +108,7 @@ export default function Web(props: { error: string; errors: ErrorInfo[] }) {
         <div className="max-w-2xl mx-auto space-y-16 text-xl leading-relaxed text-gray-800">
           {props.errors?.map((error, index, array) => {
             return (
-              <div>
+              <div key={index}>
                 <div className="prose prose-code:before:hidden prose-code:after:hidden">
                   {/* <span className="inline-block px-2 py-1 mb-2 text-xs text-indigo-900 bg-indigo-100 rounded">
                   #{error.code}

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -18,8 +18,8 @@ import { z } from 'zod';
 export default function Web(props: { error: string; errors: ErrorInfo[] }) {
   const router = useRouter();
 
-  const firstExcerpt = props.errors?.[0]?.improvedError?.excerpt;
-  const firstErrorCode = props.errors?.[0]?.code;
+  const firstExcerpt = props.errors[0]?.improvedError?.excerpt;
+  const firstErrorCode = props.errors[0]?.code;
 
   const title = `TypeScript Error Translator${
     firstErrorCode ? ` | Code #${firstErrorCode}` : ''
@@ -106,7 +106,7 @@ export default function Web(props: { error: string; errors: ErrorInfo[] }) {
         </div>
 
         <div className="max-w-2xl mx-auto space-y-16 text-xl leading-relaxed text-gray-800">
-          {props.errors?.map((error, index, array) => {
+          {props.errors.map((error, index, array) => {
             return (
               <div key={index}>
                 <div className="prose prose-code:before:hidden prose-code:after:hidden">

--- a/packages/engine/src/__tests__/engine.test.ts
+++ b/packages/engine/src/__tests__/engine.test.ts
@@ -165,6 +165,12 @@ describe('parseErrors', () => {
 
     expect(result[0].parseInfo.items).toEqual([]);
   });
+
+  it('Should return an empty array when there are no known errors', () => {
+    const errors = parseErrors('');
+
+    expect(errors).toHaveLength(0);
+  });
 });
 
 describe('fillBodyAndExcerptWithItems', () => {


### PR DESCRIPTION
Great project!

This adds a button to open a new issue that is prefilled with the error message, when an unknown error is entered.

It also adds a disabled state to the submit button when there's nothing in the input box.

<img width="863" alt="image" src="https://user-images.githubusercontent.com/3259993/190607360-4f6f9ad8-724b-4cea-b3ab-bf12160f31fc.png">

<img width="999" alt="image" src="https://user-images.githubusercontent.com/3259993/190607707-8f6c64c7-3c48-4d32-bca4-7cb13448df6f.png">

