### PR TITLE
TS-8020: Add translation for "JSDoc types can..."

### DIFF
--- a/packages/engine/errors/8020.md
+++ b/packages/engine/errors/8020.md
@@ -1,0 +1,19 @@
+---
+original: "JSDoc types can only be used inside documentation comments."
+excerpt: "I don't recognise this code and it doesn't seem to be correct TypeScript syntax."
+---
+
+This usually caused by a misplaced/unneeded operator (such as '!' or '?') like so:
+
+```ts
+interface TestInterface {
+  unitName: string,
+  last: ?boolean
+}
+```
+
+```ts
+function isString(str: string): str is string! {
+  return typeof str === 'string';
+}
+```


### PR DESCRIPTION
Provides an error translation for TypeScript error 8020