### PR TITLE
translation for 1371

### DIFF
--- a/packages/engine/errors/1371.md
+++ b/packages/engine/errors/1371.md
@@ -1,0 +1,10 @@
+---
+original: "This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'."
+excerpt: "I think the module you are importing only contains types"
+---
+
+You can add types after import 
+
+```ts
+import type Foo, { Bar, Baz } from "some-module";
+```


### PR DESCRIPTION
Type-Only Imports and Export

TypeScript 3.8 adds a new syntax for type-only imports and exports.

import type only imports declarations to be used for type annotations and declarations. It always gets fully erased, so there’s no remnant of it at runtime. Similarly, export type only provides an export that can be used for type contexts, and is also erased from TypeScript’s output.