### PR TITLE
add: 80007 error

### DIFF
--- a/packages/engine/errors/80007.md
+++ b/packages/engine/errors/80007.md
@@ -1,0 +1,6 @@
+---
+original: "'await' has no effect on the type of this expression."
+excerpt: "I was expecting a method that returns a Promise, but this one does not."
+---
+
+the use of await is only meant to be with a promise, otherwise it will be unnecessary.


### PR DESCRIPTION
This PR is adding the 80007 error translation. This error is about using the keyword "await" when there's not a Promise being returned in the current expression. 