### PR TITLE
feat: add translation for 6196

### DIFF
--- a/packages/engine/errors/6196.md
+++ b/packages/engine/errors/6196.md
@@ -1,0 +1,10 @@
+---
+original: "'{0}' is declared but never used."
+excerpt: "I noticed that '{0}' has been declared, but it's never used in the code."
+---
+
+To fix this error, you can do either of 3 things:
+
+- use A in the file
+- export it
+- set `noUnusedLocals` to false in your `tsconfig.json`


### PR DESCRIPTION
**Error**: _'{0}' is declared but never used._
**Translation**: _I noticed that '{0}' has been declared, but it's never used in the code._

## Explanation

To fix this error, you can do either of 3 things:

- use A in the file
- export it
- set `noUnusedLocals` to false in your `tsconfig.json`