### PR TITLE
feat: add translation for 2329

### DIFF
--- a/packages/engine/errors/2329.md
+++ b/packages/engine/errors/2329.md
@@ -1,0 +1,4 @@
+---
+original: "Index signature for type '{0}' is missing in type '{1}'."
+excerpt: "I was expecting '{1}' to have a property with type '{0}'."
+---


### PR DESCRIPTION
**Error**: _Index signature for type '{0}' is missing in type '{1}'._
**Translation**: _I was expecting '{1}' to have a property with type '{0}'._