### PR TITLE
(fix): [engine] Improperly indexing into params map 

### DIFF
--- a/packages/engine/src/parseErrors.ts
+++ b/packages/engine/src/parseErrors.ts
@@ -48,7 +48,7 @@ function associateMatchedParameters(
 
   for (let i = 0; i < matchedParams.length; i++) {
     const parameter = parameters[i];
-    if (!params.parameter) {
+    if (!params[parameter]) {
       params[parameter] = matchedParams[i] ?? '';
     }
   }


### PR DESCRIPTION
In `associateMatchedParameters` we are indexing into the `params` map/object while iterating over the `matchedParams` by using `params.parameter`. This should actually be `params[parameter]`.  All tests are still passing, so there seems to be no obvious regressions.