### PR TITLE
updated 2614 error explanation

### DIFF
--- a/packages/engine/errors/2614.md
+++ b/packages/engine/errors/2614.md
@@ -1,5 +1,19 @@
 ---
-original: "Module '{0}' has no exported member '{1}'. Did you mean to use 'import {1} from {0}' instead?"
+original: >
+  The file "next/image" only exports a single entity, which is exported by default.
+  You must have written 'export default {component};' somewhere, which means that this particular file exports only this 'component'.
+  Thus, whenever you are going to import this component into some other file, you must write:
+  import component from 'next/file'.
+
+  However, if you write it as:
+  import {component} from 'next/file',
+  it would mean that this component from this file is a named export.
+  A named export means that a file already has a default export, and the 'component' you are trying to import is exported by other means.
+
+  So, in our case, this error arises because the file "next/image" is exporting the Image as a default export, not as a named export.
+  Therefore, we must import it as:
+  import Image from 'next/image'.
+
 ---
 
 '{1}' is not one of the things exported from '{0}'. Did you mean to import '{1}' from '{0}' instead?


### PR DESCRIPTION
Made some clear explanations on why we should write import Image from "next/image" instead of import {Image} from "next/Image". 